### PR TITLE
add buildpack name

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,5 @@
 #! /bin/bash
 
 # Always use when requested
+echo "Vips Library"
 exit 0


### PR DESCRIPTION
Without echoing a build pack name, `Heroku` doesn't initiate compile phase.
