### PR TITLE
Support Heroku's multi-buildpacks feature

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,5 @@
 #! /bin/bash
 
 # Always use when requested
+echo VIPS
 exit 0


### PR DESCRIPTION
Heroku's new [multi-buildpacks feature](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app) requires `bin/detect` to print a "human-readable framework name" to stdout.

See https://devcenter.heroku.com/articles/buildpack-api#bin-detect
