### PR TITLE
fix $PKG_CONFIG_PATH append

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ echo "libvips installed" | indent
 
 #echo "Creating new env var in $3" | indent
 
-echo "\$PKG_CONFIG_PATH:/app/vendor/vips/lib/pkgconfig" > $3/PKG_CONFIG_PATH
+echo "$PKG_CONFIG_PATH:/app/vendor/vips/lib/pkgconfig" > $ENVFILE/PKG_CONFIG_PATH
 
 #echo "Installing vips .profile.d files" | indent
 


### PR DESCRIPTION
The append to `$PKG_CONFIG_PATH` is broken -- the original code results in a literal value of `$PKG_CONFIG_PATH:/app/vendor/vips/lib/pkgconfig` due to the escaped `\$`, instead of allowing the original value to resolve through.

This PR fixes it so this buildpack doesn't clobber previously-set PKG_CONFIG_PATH values.
